### PR TITLE
feat(Google Drive): Enable spreadsheet search in Shared Drives

### DIFF
--- a/org.knime.ext.google.filehandling.drive/src/org/knime/ext/google/filehandling/drive/fs/GoogleDriveHelper.java
+++ b/org.knime.ext.google.filehandling.drive/src/org/knime/ext/google/filehandling/drive/fs/GoogleDriveHelper.java
@@ -167,6 +167,8 @@ public class GoogleDriveHelper {
 
         if (driveId != null) {
             addDriveIdToQuery(query, driveId);
+        } else {
+            addSearchAllDrivesToQuery(query);
         }
 
         FileList result = query.execute();
@@ -401,6 +403,8 @@ public class GoogleDriveHelper {
                 .setSpaces("drive");
         if (driveId != null) {
             addDriveIdToQuery(query, driveId);
+        } else {
+            addSearchAllDrivesToQuery(query);
         }
 
         final List<File> files = new LinkedList<>();
@@ -426,7 +430,17 @@ public class GoogleDriveHelper {
     private static void addDriveIdToQuery(final Files.List query, final String driveId) {
         query.setDriveId(driveId);
         query.setIncludeItemsFromAllDrives(true);
-        query.setCorpora("drive");
+        query.setCorpora("allDrives");
+        query.setSupportsAllDrives(true);
+        
+    }
+
+    /**
+     * @param query
+     */
+    private static void addSearchAllDrivesToQuery(final Files.List query) {
+        query.setIncludeItemsFromAllDrives(true);
+        query.setCorpora("allDrives");
         query.setSupportsAllDrives(true);
     }
 

--- a/org.knime.google.api/src/org/knime/google/api/sheets/nodes/util/DialogComponentGoogleSpreadsheetChooser.java
+++ b/org.knime.google.api/src/org/knime/google/api/sheets/nodes/util/DialogComponentGoogleSpreadsheetChooser.java
@@ -445,6 +445,9 @@ public class DialogComponentGoogleSpreadsheetChooser extends DialogComponent {
         final List<File> spreadsheets = new ArrayList<File>();
         final com.google.api.services.drive.Drive.Files.List request =
                 m_sheetsConnection.getDriveService().files().list()
+                .setCorpora("allDrives")
+                .setIncludeItemsFromAllDrives(true)
+                .setSupportsAllDrives(true)
                 .setQ("mimeType='application/vnd.google-apps.spreadsheet'");
 
         do {


### PR DESCRIPTION
The Google Spreadsheet chooser was previously limited to finding files within the user's "My Drive". This prevented users from selecting spreadsheets stored in Shared Drives, which is a critical feature for collaborative team environments.

This commit updates the Drive API file list request by adding the required parameters to search across all corpora:
- setCorpora("allDrives")
- setIncludeItemsFromAllDrives(true)
- setSupportsAllDrives(true)

As a result, the file chooser dialog can now discover and list spreadsheets from both "My Drive" and any Shared Drives the user has access to.